### PR TITLE
Generate `rulesDirectory` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,7 @@ Create a file in the project root named `tslint.json` containing the following:
 
 ```json
 {
-    "extends": "@morrisallison/tslint-config",
-    "rulesDirectory": [
-        "node_modules/@morrisallison/tslint-config/rules",
-        "node_modules/tslint-eslint-rules/dist/rules",
-        "node_modules/tslint-microsoft-contrib",
-        "node_modules/vrsource-tslint-rules/rules"
-    ]
+    "extends": "@morrisallison/tslint-config"
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var msRecommended = require('tslint-microsoft-contrib/recommended_ruleset');
 
 var tslintEslint = require('./rulesets/tslint-eslint-rules');

--- a/index.js
+++ b/index.js
@@ -1,31 +1,46 @@
 'use strict';
 
-var msRecommended = require('tslint-microsoft-contrib/recommended_ruleset');
+const msRecommended = require('tslint-microsoft-contrib/recommended_ruleset');
+const resolve = require('resolve');
+const path = require('path');
 
-var tslintEslint = require('./rulesets/tslint-eslint-rules');
-var vrsource = require('./rulesets/vrsource-tslint-rules');
+const overrides = require('./rulesets/overrides');
+const tslintEslint = require('./rulesets/tslint-eslint-rules');
+const vrsource = require('./rulesets/vrsource-tslint-rules');
 
-var overrides = {
-    'curly': false,
-    'function-name': false,
-    'interface-name': false,
-    'missing-jsdoc': false,
-    'no-any': false,
-    'no-for-in-array': false,
-    'no-increment-decrement': false,
-    'no-multiline-string': false,
-    'no-relative-imports': false,
-    'no-single-line-block-comment': false,
-    'one-variable-per-declaration': false,
-    'ordered-imports': false,
-    'prefer-array-literal': false,
-    'restrict-plus-operands': false,
-    'trailing-comma': false,
+function makeRules() {
+    const rules = Object.assign(
+        {},
+        msRecommended.rules,
+        tslintEslint.rules,
+        vrsource.rules,
+        overrides.rules
+    );
+
+    // Hide annoying deprecated message
+    delete rules['no-unused-variable'];
+
+    return rules;
+}
+
+function getDirectories() {
+    const customRulesDirectory = path.resolve(__dirname, 'rules');
+    const msRulesDirectory = path.resolve(require.resolve('tslint-microsoft-contrib'), '..');
+    const eslintRulesDirectory = path.resolve(require.resolve('tslint-eslint-rules'), '../dist/rules');
+
+    // Assuming the location of the "node_modules" path, because `vrsource-tslint-rules` can't be resolved
+    const nodeModules = path.dirname(msRulesDirectory);
+    const vrsourceRulesDirectory = path.join(nodeModules, 'vrsource-tslint-rules/rules');
+
+    return [
+        customRulesDirectory,
+        msRulesDirectory,
+        eslintRulesDirectory,
+        vrsourceRulesDirectory,
+    ];
+}
+
+module.exports = {
+    rules: makeRules(),
+    rulesDirectory: getDirectories(),
 };
-
-var rules = Object.assign({}, msRecommended.rules, tslintEslint.rules, vrsource.rules, overrides);
-
-// Hide annoying deprecated message
-delete rules['no-unused-variable'];
-
-module.exports = { rules: rules };

--- a/rulesets/overrides.json
+++ b/rulesets/overrides.json
@@ -1,0 +1,19 @@
+{
+    "rules": {
+        "curly": false,
+        "function-name": false,
+        "interface-name": false,
+        "missing-jsdoc": false,
+        "no-any": false,
+        "no-for-in-array": false,
+        "no-increment-decrement": false,
+        "no-multiline-string": false,
+        "no-relative-imports": false,
+        "no-single-line-block-comment": false,
+        "one-variable-per-declaration": false,
+        "ordered-imports": false,
+        "prefer-array-literal": false,
+        "restrict-plus-operands": false,
+        "trailing-comma": false
+    }
+}

--- a/rulesets/tslint-eslint-rules.json
+++ b/rulesets/tslint-eslint-rules.json
@@ -1,4 +1,4 @@
-module.exports = {
+{
     "rules": {
         "block-spacing": true,
         "brace-style": "1tbs",
@@ -14,4 +14,4 @@ module.exports = {
         "ter-arrow-spacing": true,
         "valid-typeof": true
     }
-};
+}

--- a/rulesets/vrsource-tslint-rules.json
+++ b/rulesets/vrsource-tslint-rules.json
@@ -1,4 +1,4 @@
-module.exports = {
+{
     "rules": {
         "ext-variable-name": [
             true,
@@ -15,4 +15,4 @@ module.exports = {
         "no-duplicate-imports": true,
         "prefer-literal": [true, "object", "function", "array"]
     }
-};
+}


### PR DESCRIPTION
The `"rulesDirectory"` property no longer needs to be set by consumers.